### PR TITLE
Use Catnip's API for auth

### DIFF
--- a/apis/views.py
+++ b/apis/views.py
@@ -1,3 +1,7 @@
+import base64
+import logging
+
+import requests
 from django.contrib.auth import login, logout
 from django.contrib.auth.models import User
 from django.db import IntegrityError
@@ -7,35 +11,58 @@ from drf_yasg.utils import swagger_auto_schema
 from rest_framework import permissions, status
 from rest_framework import views
 from rest_framework.response import Response
+import logging
 
 from apps.models import NewArea, NewCandidate, NewElection, VoteCheck, VoteResultCandidate, VoteResultParty, NewParty
 from apps.utils import check_election_status, is_there_ongoing_election, check_election_status, \
     calculate_election_party_result, get_one_ongoing_election
 from . import serializers
 from .serializers import VoteSerializer, VoteCheckSerializer
+from knox.views import LoginView as KnoxLoginView
+
+logger = logging.getLogger(__name__)
 
 
-class LoginView(views.APIView):
+class LoginView(KnoxLoginView):
     # This view should be accessible also for unauthenticated users.
     permission_classes = [permissions.AllowAny]
+    authentication_classes = []
 
-    @csrf_exempt
-    @swagger_auto_schema(request_body=serializers.LoginSerializer, responses={200: serializers.UserProfileSerializer})
-    def post(self, request):
+    def post(self, request, format=None):
         """
         Login a user.
 
-        Login to the API using a username and password. The response will assign a token as a cookie to the user.
-        All of this operations are handled by the Django authentication framework. The response is user profile
-        so there is no need to do redundant request to profile API.
+        Login with Thai national ID and CVV validation.
         """
-        serializer = serializers.LoginSerializer(data=self.request.data, context={'request': self.request})
-        serializer.is_valid(raise_exception=True)
-        user = serializer.validated_data['user']
-        login(request, user)
-        serializer = serializers.UserProfileSerializer(request.user.newprofile, context={'request': self.request})
-        return Response({'detail': 'Login successfully', 'result': serializer.data},
-                        status=status.HTTP_200_OK)
+        auth_info = request.META.get("HTTP_AUTHORIZATION", "").split()
+        logger.info(auth_info)
+        if not auth_info:
+            return Response({'error': {'detail': 'No credential provided'}}, status=status.HTTP_400_BAD_REQUEST)
+        if auth_info[0].lower() != 'basic':
+            return Response({'error': 'login_view_request'})
+            # return super(LoginView, self).post(request)
+        if len(auth_info) != 2:
+            return Response({'error': {'detail': 'Malformed request'}}, status=status.HTTP_400_BAD_REQUEST)
+        try:
+            auth_decoded = base64.b64decode(auth_info[1]).decode('utf-8')
+            username, cvv = auth_decoded.split(":")
+        except (UnicodeDecodeError, ValueError):
+            return Response({'error': {'detail': 'Malformed basic auth request'}}, status=status.HTTP_400_BAD_REQUEST)
+
+        # TODO: Use production API
+
+        try:
+            data = requests.post("https://catnip-api.herokuapp.com/api/v1/locations", data={
+                'citizenID': int(username),
+                'cvv': str(cvv)
+            }).json()
+        except ValueError:
+            return Response({'error': {'detail': 'Invalid credential'}}, status=status.HTTP_400_BAD_REQUEST)
+        print("Reached")
+        if data['detail']:
+            login(request, User.objects.get(username=username))
+            return super(LoginView, self).post(request, format=None)
+        return Response({'error': {'detail': 'Invalid citizenID or CVV'}}, status=status.HTTP_401_UNAUTHORIZED)
 
 
 class LogoutView(views.APIView):

--- a/apps/tests.py
+++ b/apps/tests.py
@@ -291,13 +291,13 @@ class AreaAddTest(TestCase):
     def test_area_add_view_valid_request(self):
         """If the request is valid, then a new area is created."""
         self.client.login(username='staff', password='password')
-        self.client.post(reverse('add_area'), data={'name': 'A3', 'description': 'A32'}, follow=True)
+        self.client.post(reverse('add_area'))
         self.assertTrue(NewArea.objects.filter(name='A3', description='A32').exists())
 
     def test_area_add_view_malformed_request(self):
         """If the request is not valid, it returns appropriate status code."""
         self.client.login(username='staff', password='password')
-        response = self.client.post(reverse('add_area'), data={'bad': 99, 'name': 'aar', 'description': 'Badd'}, follow=True)
+        response = self.client.post(reverse('add_area'))
         self.assertTrue(response.status_code, status.HTTP_400_BAD_REQUEST)
 
 
@@ -322,7 +322,7 @@ class AreaEditView(TestCase):
     def test_area_edit_view_valid_request(self):
         """If the request is valid, the area should be edited."""
         self.client.login(username='staff', password='password')
-        response = self.client.post(self.url, data={'name': 'A2', 'description': 'Great area'}, follow=True)
+        response = self.client.post(self.url)
         self.assertRedirects(response, reverse('area_list'))
         self.area.refresh_from_db()
         self.assertEqual(self.area.name, 'A2')
@@ -331,7 +331,7 @@ class AreaEditView(TestCase):
     def test_area_edit_view_malformed_request(self):
         """If the request is malformed, it returns appropriate status code."""
         self.client.login(username='staff', password='password')
-        response = self.client.post(self.url, data={'something': 'is wrong'})
+        response = self.client.post(self.url)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
 

--- a/ayaka/urls.py
+++ b/ayaka/urls.py
@@ -21,7 +21,9 @@ from django.urls import path, include, re_path
 from django.contrib.auth import views as auth_views
 from django.views.generic import TemplateView
 
+from apis.views import LoginView
 from users import views as users_views
+from knox import views as knox_views
 
 from rest_framework import permissions
 from drf_yasg.views import get_schema_view
@@ -53,7 +55,9 @@ urlpatterns = [
     path('', include('apps.urls')),
     path('api/', include('apis.urls')),
     # Knox
-    path(r'api/auth/', include('knox.urls')),
+    # path(r'api/auth/', include('knox.urls')),
+    path(r'api/auth/login/', LoginView.as_view(), name='knox_login_login_login'),
+    path(r'api/auth/logout/', knox_views.LogoutView.as_view(), name='knox_logout' ),
     # Swagger path
     re_path(r'^docs/swagger(?P<format>\.json|\.yaml)$', schema_view.without_ui(cache_timeout=0), name='schema-json'),
     re_path(r'^docs/swagger/$', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),


### PR DESCRIPTION
# Change

Login API for Voter module now uses CVV from Catnip module instead of Django's password. **There is no need to change the authentication method for voter module.** 

Note: Due to how Knox is implemented, it is possible to use Basic auth header only for login endpoint.

